### PR TITLE
fix: order list in admonition block

### DIFF
--- a/custom-safari.css
+++ b/custom-safari.css
@@ -246,7 +246,7 @@ html.is-electron.is-mac .cp__header {
   margin: unset;
 }
 .content .admonitionblock .is-paragraph {
-  font-size: 0.8em;
+  font-size: 0.9rem;
   margin-left: -0.6rem;
 }
 .content .admonitionblock .admonition-icon {
@@ -326,6 +326,9 @@ html.is-electron.is-mac .cp__header {
   font-family: MonoLisa, "Fira Code", Monaco, Menlo, Consolas, "COURIER NEW", monospace;
   padding: 0.2em 0.4em !important;
   color: #EB5757;
+}
+.content .text-lg {
+  font-size: 0.9em;
 }
 
 .tippy-wrapper {

--- a/custom.css
+++ b/custom.css
@@ -245,9 +245,10 @@ html.is-electron.is-mac .cp__header {
   background-color: var(--ls-callout-background-color);
   margin: unset;
 }
-.content .admonitionblock .is-paragraph {
-  font-size: 0.9rem;
-  margin-left: -0.6rem;
+.content .admonitionblock .text-lg {
+  font-size: 0.9em;
+  margin-left: 0;
+  line-height: 1.35rem;
 }
 .content .admonitionblock .admonition-icon {
   padding-right: 0.65em;
@@ -326,9 +327,6 @@ html.is-electron.is-mac .cp__header {
   font-family: MonoLisa, "Fira Code", Monaco, Menlo, Consolas, "COURIER NEW", monospace;
   padding: 0.2em 0.4em !important;
   color: #EB5757;
-}
-.content .text-lg {
-  font-size: 0.9em;
 }
 
 .tippy-wrapper {

--- a/custom.css
+++ b/custom.css
@@ -327,7 +327,7 @@ html.is-electron.is-mac .cp__header {
   padding: 0.2em 0.4em !important;
   color: #EB5757;
 }
-.content .text-lg{
+.content .text-lg {
   font-size: 0.9em;
 }
 

--- a/custom.css
+++ b/custom.css
@@ -246,7 +246,7 @@ html.is-electron.is-mac .cp__header {
   margin: unset;
 }
 .content .admonitionblock .is-paragraph {
-  font-size: 0.8em;
+  font-size: 0.9rem;
   margin-left: -0.6rem;
 }
 .content .admonitionblock .admonition-icon {
@@ -326,6 +326,9 @@ html.is-electron.is-mac .cp__header {
   font-family: MonoLisa, "Fira Code", Monaco, Menlo, Consolas, "COURIER NEW", monospace;
   padding: 0.2em 0.4em !important;
   color: #EB5757;
+}
+.content .text-lg{
+  font-size: 0.9em;
 }
 
 .tippy-wrapper {

--- a/source/theme.scss
+++ b/source/theme.scss
@@ -118,9 +118,10 @@
         padding: 16px 16px 16px 12px;
         background-color: var(--ls-callout-background-color);
         margin: unset;
-        .is-paragraph {
-            font-size: 0.8em;
-            margin-left: -0.6rem;
+        .text-lg {
+            font-size: 0.9em;
+            margin-left: 0;
+            line-height: 1.35rem;
         }
         .admonition-icon {
             padding-right: 0.65em;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/76084546/122236973-89d7e600-cef1-11eb-801c-6694247ac9af.png)

After:
![image](https://user-images.githubusercontent.com/76084546/122237047-96f4d500-cef1-11eb-8a38-50e105c5afa0.png)

Changed:
https://github.com/Sansui233/logseq-bonofix-theme/blob/2ecef1bbc07311d77c7292a19a4a6add54c626ff/custom.css#L248-L251
https://github.com/Sansui233/logseq-bonofix-theme/blob/2ecef1bbc07311d77c7292a19a4a6add54c626ff/custom.css#L330-L332